### PR TITLE
Some fixes when using MADGRAD (Softplus and Stable weight decay)

### DIFF
--- a/ranger21/ranger21.py
+++ b/ranger21/ranger21.py
@@ -74,7 +74,7 @@ def get_chebs(num_epochs):
 
 def normalize_gradient(x, use_channels=False, epsilon=1e-8):
     """  use stdev to normalize gradients """
-    size = len(list(x.size()))
+    size = x.dim()
     # print(f"size = {size}")
 
     if (size > 1) and use_channels:
@@ -91,7 +91,7 @@ def normalize_gradient(x, use_channels=False, epsilon=1e-8):
 def centralize_gradient(x, gc_conv_only=False):
     """credit - https://github.com/Yonghongwei/Gradient-Centralization """
 
-    size = len(list(x.size()))
+    size = x.dim()
     # print(f"size = {size}")
 
     if gc_conv_only:

--- a/ranger21/ranger21.py
+++ b/ranger21/ranger21.py
@@ -702,7 +702,10 @@ class Ranger21(TO.Optimizer):
             raise ValueError("failed to set param size")
 
         # stable weight decay
-        variance_normalized = math.sqrt(variance_ma_sum / param_size)
+        if self.use_madgrad:
+            variance_normalized = torch.pow(variance_ma_sum / param_size, 1/3)
+        else:
+            variance_normalized = math.sqrt(variance_ma_sum / param_size)
         # variance_mean = variance_ma_sum / param_size
         if math.isnan(variance_normalized):
             raise RuntimeError("hit nan for variance_normalized")

--- a/ranger21/ranger21.py
+++ b/ranger21/ranger21.py
@@ -808,7 +808,7 @@ class Ranger21(TO.Optimizer):
                     s = state["s"]
                     if momentum == 0:
                         # Compute x_0 from other known quantities
-                        rms = grad_sum_sq.pow(1 / 3).add_(eps)
+                        rms = F.softplus(grad_sum_sq.pow(1 / 3), beta=50)
                         x0 = p.data.addcdiv(s, rms, value=1)
                     else:
                         x0 = state["x0"]
@@ -820,7 +820,7 @@ class Ranger21(TO.Optimizer):
                     # print(f"gsumsq = {grad_sum_sq}")
 
                     grad_sum_sq.addcmul_(inner_grad, inner_grad, value=lamb)
-                    rms = grad_sum_sq.pow(1 / 3).add_(eps)
+                    rms = F.softplus(grad_sum_sq.pow(1 / 3), beta=50)
 
                     # Update s
                     s.data.add_(inner_grad, alpha=lamb)


### PR DESCRIPTION
Hi,

While studying the Ranger21 code with MADGRAD as the main optimizer, I asked myself the following questions :
- Is Softplus transformation implemented with MADGRAD in your framework ?
- How do you perform stable weight decay with MADGRAD ?

I think you tested softplus transformation with AdamW as main optimizer but not with MADGRAD so I fixed it (I made the assumption that beta=50 is still the optimal beta for softplus).
For Stable weight decay, I used a cube root instead of a square root in order to have the same range of value for theta(t-1) and m(t).
I also replaced `len(list(x.size()))` by `x.dim()` in the gradient centralization part (shorter and a bit faster).

I ran some tests with a CNN architecture on a split of ESC-50 dataset (spectrograms) to ensure I broke nothing :
![Capture d’écran 2021-07-18 à 17 52 33](https://user-images.githubusercontent.com/47749560/126074966-f8d11fdd-770b-4b54-ba12-490650cf33ce.png)
![Capture d’écran 2021-07-18 à 17 52 11](https://user-images.githubusercontent.com/47749560/126074967-62ccff05-0cff-4801-997f-40797e2fad07.png)
The orange curve is ranger21 without modifications.
The blue one is with the sofplus modification.
The red one is with the softplus modification and the stable weight decay using cubic root.
It is not clear if it really helps but it seems that both modification improve convergence.
I kept the same configuration between runs which is the following :
```yaml
lr: 0.0007
lookahead_active: False
lookahead_mergetime: 5
lookahead_blending_alpha: 0.5
lookahead_load_at_validation: False
use_madgrad: True
use_adabelief: False
softplus: True
using_gc: True
using_normgc: True
gc_conv_only: False
normloss_active: True
normloss_factor: 1e-4
use_adaptive_gradient_clipping: True
agc_clipping_value: 1e-2
agc_eps: 1e-3
momentum_type: pnm
pnm_momentum_factor: 1.0
momentum: 0.9
eps: 1e-8
num_batches_per_epoch: 26
num_epochs: 250
use_cheb: False
use_warmup: False
num_warmup_iterations: None
warmdown_active: False
warmdown_start_pct: 0.72
warmdown_min_lr: 1e-5
weight_decay: 1e-4
decay_type: stable
warmup_type: linear
warmup_pct_default: 0.22
logging_active: True
```
I hope it will help you in your investigations.

PS : I love your work, I also tried to modify MADGRAD and thanks to you I discovered great new papers on optimizers.