### PR TITLE
allow parallel, division by zero error

### DIFF
--- a/ranger21/ranger21.py
+++ b/ranger21/ranger21.py
@@ -580,7 +580,7 @@ class Ranger21(TO.Optimizer):
                 loss = closure()
 
         param_size = 0
-        variance_ma_sum = 0.0
+        variance_ma_sum = 1.0
 
         # phase 1 - accumulate all of the variance_ma_sum to use in stable weight decay
 


### PR DESCRIPTION
when running in patch based parallel pipeline ranger 21 faults on division by zero almost immediately. I had to initialized variance_ma_sum with 1.0 instead and results match normal adamw except converging faster